### PR TITLE
Binding custom transaction to scope

### DIFF
--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -46,7 +46,8 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
     func purchase() {
         let transaction = SentrySDK.startTransaction(
           name: "purchase",
-          operation: "http.client" // 'http.client' appears automatically in our js app, don't have to set 'operation' // this param is mandatory
+          operation: "http.client", // 'http.client' appears automatically in our js app, don't have to set 'operation' // this param is mandatory
+          bindToScope: true // needed for distributed tracing - It binds a transaction to the scope making it accessible to every method running
         )
 
         // use localhost for development against dev-backend


### PR DESCRIPTION
## Type of Change


[x] Bugfix
[ ] New Feature
[ ] Enhancement
[ ] Refactoring

## Description

Fixing distributed tracing for iOS. The problem seemed to be that we were not binding the custom transaction to the current scope which makes it accessible to every method running within the scope as detailed [here](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope) 

## Testing


`test_checkout_ios`
- [saucelabs test](https://app.saucelabs.com/tests/0caa019afd4d49da9eadfa70ee37c73c)
- [sentry transaction](https://sentry.io/organizations/testorg-az/performance/sergio-ios:e215364fa2124c7689f0155ad8942b95/?project=6748045&query=transaction.duration%3A%3C15m&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=24h&transaction=purchase&unselectedSeries=p100%28%29)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3794201444/events/a0fd2cf60949440985f188dd95883ba7/?project=6748045)
- [sentry profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-ios/3a6b37733f0f4cc3bd5ca36e027f20ae/flamechart/?colorCoding=by+symbol+name&fov=0%2C0%2C649547648%2C23&query=&sorting=call+order&tid=259&view=top+down&xAxis=standalone)