### PR TITLE
Add readCurrentDirectory slow method for profiling

### DIFF
--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -25,6 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 options.tracesSampleRate = 1.0
                 options.profilesSampleRate = 1.0
                 options.enableCoreDataTracking = true
+                options.enableFileIOTracking = true
             }
         return true
     }

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Sentry
 
 class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    
+
     // CoreData database
     let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
     
@@ -25,7 +25,7 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Empower Plant"
-        
+
         self.view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
@@ -35,12 +35,13 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
         
         // Configures the nav bar buttons
         configureNavigationItems()
-        
+
         /* TODO
          1 get products from server (so we get http.client span)
          2 check if any products in Core Data -> If Not -> insert the products from response into Core Data
          3 get products from DB (so we get db.query span) and reload the table with this data
          */
+        
         getAllProductsFromServer()
         getAllProductsFromDb()
         getCacheDirectory()

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -69,10 +69,8 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
             for item in items {
                 var isDirectory: ObjCBool = false
                 if fm.fileExists(atPath: item, isDirectory: &isDirectory) {
-                    print(item)
                     readDirectory(path: item)
                 } else {
-                    print(item)
                     return
                 }
             }

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Sentry
 
 class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
+    
     // CoreData database
     let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
     
@@ -25,7 +25,7 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Empower Plant"
-
+        
         self.view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
@@ -35,15 +35,16 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
         
         // Configures the nav bar buttons
         configureNavigationItems()
-
+        
         /* TODO
          1 get products from server (so we get http.client span)
          2 check if any products in Core Data -> If Not -> insert the products from response into Core Data
          3 get products from DB (so we get db.query span) and reload the table with this data
          */
-        
+        generateId()
         getAllProductsFromServer()
         getAllProductsFromDb()
+        
     }
     
     @objc
@@ -135,14 +136,44 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
     func getAllProductsFromDb() {
         do {
             self.products = try context.fetch(Product.fetchRequest())
-        // for product in self.products {
-        //     print(product.productId, product.title, product.productDescriptionFull)
-        // }
+            // for product in self.products {
+            //     print(product.productId, product.title, product.productDescriptionFull)
+            // }
             refreshTable()
         }
         catch {
             // error
         }
+    }
+    
+    @objc
+    func generateId() -> Int {
+        if (self.products.isEmpty) {
+            getAllProductsFromServer()
+            getAllProductsFromDb()
+        }
+        
+        var existingIds = [Int]()
+        for product in self.products {
+            let intId = Int(product.productId ?? "")
+            existingIds.append(intId ?? 0)
+        }
+        
+        return createId(ids:existingIds)
+    }
+    
+    @objc
+    func createId(ids: [Int]) -> Int {
+        for _ in 1...5 {
+            let rand = Int.random(in: (3)..<(5))
+            if (!ids.contains(rand)) {
+                return rand
+            }
+            sleep(2)
+            print(rand)
+        }
+        
+        return 0
     }
     
     // Also writes them into database if database is empty

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -200,50 +200,6 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
         }
     }
     
-    @objc
-    func generateId() -> Int {
-        if (self.products.isEmpty) {
-            getAllProductsFromServer()
-            getAllProductsFromDb()
-        }
-        
-        var existingIds = [Int]()
-        for product in self.products {
-            let intId = Int(product.productId ?? "")
-            existingIds.append(intId ?? 0)
-        }
-
-        for j in 1...80 {
-            let rand = fib(num: j)
-            if (!existingIds.contains(rand)) {
-                //return rand
-            }
-            //sleep(2)
-            print(rand)
-        }
-        
-        return 0
-    }
-    
-    
-    @objc
-    func fib(num: Int) -> Int{
-       // The value of 0th and 1st number of the fibonacci series are 0 and 1
-       var n1 = 0
-       var n2 = 1
-
-       // To store the result
-       var nR = 0
-       // Adding two previous numbers to find ith number of the series
-       for _ in 0..<num{
-          nR = n1
-          n1 = n2
-          n2 = nR + n2
-       }
-       return n1
-    }
-    
-    
     // Also writes them into database if database is empty
     func getAllProductsFromServer() {
         let url = URL(string: "https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products-join")!

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -41,10 +41,64 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
          2 check if any products in Core Data -> If Not -> insert the products from response into Core Data
          3 get products from DB (so we get db.query span) and reload the table with this data
          */
-        generateId()
         getAllProductsFromServer()
         getAllProductsFromDb()
+        getCacheDirectory()
         
+    }
+    
+    func getCacheDirectory() {
+        let path = FileManager.default.currentDirectoryPath
+        do {
+            let items = try FileManager.default.contentsOfDirectory(atPath: path)
+            let loop = fibonacciSeries(num: items.count)
+            for i in 1...loop {
+                readDirectory(path: path)
+            }
+        } catch {
+            
+        }
+    }
+    
+    func readDirectory(path: String) {
+        let fm = FileManager.default
+        
+        do {
+            let items = try fm.contentsOfDirectory(atPath: path)
+            
+            for item in items {
+                var isDirectory: ObjCBool = false
+                if fm.fileExists(atPath: item, isDirectory: &isDirectory) {
+                    print(item)
+                    readDirectory(path: item)
+                } else {
+                    print(item)
+                    return
+                }
+            }
+        } catch {
+        }
+        
+    }
+    
+    func fibonacciSeries(num: Int) -> Int{
+       // The value of 0th and 1st number of the fibonacci series are 0 and 1
+       var n1 = 0
+       var n2 = 1
+
+       // To store the result
+       var nR = 0
+       // Adding two previous numbers to find ith number of the series
+       for _ in 0..<num{
+          nR = n1
+          n1 = n2
+          n2 = nR + n2
+       }
+    
+       if (n1 < 4000) {
+           return fibonacciSeries(num: n1)
+       }
+       return n1
     }
     
     @objc
@@ -159,17 +213,36 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
             existingIds.append(intId ?? 0)
         }
 
-        for _ in 1...5 {
-            let rand = Int.random(in: (3)..<(5))
+        for j in 1...80 {
+            let rand = fib(num: j)
             if (!existingIds.contains(rand)) {
-                return rand
+                //return rand
             }
-            sleep(2)
+            //sleep(2)
             print(rand)
         }
         
         return 0
     }
+    
+    
+    @objc
+    func fib(num: Int) -> Int{
+       // The value of 0th and 1st number of the fibonacci series are 0 and 1
+       var n1 = 0
+       var n2 = 1
+
+       // To store the result
+       var nR = 0
+       // Adding two previous numbers to find ith number of the series
+       for _ in 0..<num{
+          nR = n1
+          n1 = n2
+          n2 = nR + n2
+       }
+       return n1
+    }
+    
     
     // Also writes them into database if database is empty
     func getAllProductsFromServer() {

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -158,15 +158,10 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
             let intId = Int(product.productId ?? "")
             existingIds.append(intId ?? 0)
         }
-        
-        return createId(ids:existingIds)
-    }
-    
-    @objc
-    func createId(ids: [Int]) -> Int {
+
         for _ in 1...5 {
             let rand = Int.random(in: (3)..<(5))
-            if (!ids.contains(rand)) {
+            if (!existingIds.contains(rand)) {
                 return rand
             }
             sleep(2)

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -44,11 +44,11 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
         
         getAllProductsFromServer()
         getAllProductsFromDb()
-        getCacheDirectory()
+        readCurrentDirectory()
         
     }
     
-    func getCacheDirectory() {
+    func readCurrentDirectory() {
         let path = FileManager.default.currentDirectoryPath
         do {
             let items = try FileManager.default.contentsOfDirectory(atPath: path)


### PR DESCRIPTION
## Type of Change


[ ] Bugfix
[x] New Feature
[ ] Enhancement
[ ] Refactoring

## Description

Introducing a method `readCurrentDirectory` which performs some I/O operations and loops through the current directory folders. This is a heavy performant operation on the CPU which causes a slow profile. This method also uses Fibonacci to generate a large number that defines how many times this process is repeated.

## Testing


`test_checkout_ios`
- [saucelabs error](https://app.saucelabs.com/tests/e30ba2077da44caaa3e4d501b92a3878)
- [sentry profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-ios/392a96a7b3494b33a184361eb8a96268/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&view=top+down&xAxis=profile)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3794201444/events/64bc7953cf444cbfbd3a7bf94265c6fd/?project=6748045)
- [sentry transaction](https://sentry.io/organizations/testorg-az/performance/sergio-ios:9656dbbd7d654f79b0336ea8c78142ff/)
