### PR TITLE
Update sdk 8.4.0 and add TTID/TTFD spans

### DIFF
--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 options.enableCoreDataTracing = true
                 options.enableFileIOTracing = true
                 options.attachScreenshot = true
+                options.enableTimeToFullDisplay = true
             }
         return true
     }

--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -18,7 +18,7 @@ protocol URLSessionDataTaskProtocol {
 
 class CartViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
-    private let session: URLSessionProtocol
+    //private let session: URLSessionProtocol
 
     let tableView: UITableView = {
         let table = UITableView()
@@ -28,12 +28,13 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     // Used for mocking in unit test
     init(session: URLSessionProtocol = URLSession.shared as! URLSessionProtocol) {
-        self.session = session
+        //self.session = session
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        //fatalError("init(coder:) has not been implemented")
+        super.init(nibName: nil, bundle: nil)
     }
     
     override func viewDidLoad() {

--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -52,6 +52,7 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
 
         // TODO make this 'total' appear in a UI element
         print("CartViewController | TOTAL", ShoppingCart.instance.total)
+        SentrySDK.reportFullyDisplayed()
     }
 
     private func configureNavigationItems() {

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -24,6 +24,7 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        SentrySDK.reportFullyDisplayed()
         title = "Empower Plant"
 
         self.view.addSubview(tableView)

--- a/EmpowerPlant/Info.plist
+++ b/EmpowerPlant/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.7</string>
+	<string>0.0.8</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Podfile
+++ b/Podfile
@@ -6,5 +6,5 @@ target 'EmpowerPlant' do
   use_frameworks!
 
   # Pods for EmpowerPlant
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.3.3'
+  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.4.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Sentry (8.3.3):
-    - Sentry/Core (= 8.3.3)
-    - SentryPrivate (= 8.3.3)
-  - Sentry/Core (8.3.3):
-    - SentryPrivate (= 8.3.3)
-  - SentryPrivate (8.3.3)
+  - Sentry (8.4.0):
+    - Sentry/Core (= 8.4.0)
+    - SentryPrivate (= 8.4.0)
+  - Sentry/Core (8.4.0):
+    - SentryPrivate (= 8.4.0)
+  - SentryPrivate (8.4.0)
 
 DEPENDENCIES:
-  - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `8.3.3`)
+  - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `8.4.0`)
 
 SPEC REPOS:
   trunk:
@@ -16,17 +16,17 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
-    :tag: 8.3.3
+    :tag: 8.4.0
 
 CHECKOUT OPTIONS:
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
-    :tag: 8.3.3
+    :tag: 8.4.0
 
 SPEC CHECKSUMS:
-  Sentry: 8ffc397d98fe58d693e73959b26ed0eaee55646a
-  SentryPrivate: bf776a47a131648f5023097215987b40fbd47025
+  Sentry: 16d46dd5ca10e7f4469a2611805a3de123188add
+  SentryPrivate: 2bb4f8d9ff558b25ac70b66c1dedc58a7c43630b
 
-PODFILE CHECKSUM: 909118885f1210ac516b9e15deb52a372230da94
+PODFILE CHECKSUM: 74c299574113e0656c8e7b4a2c9899ac27db19a9
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Type of Change

[ x ] Enhancement

## Description

Update `sentry-cocoa` version to `8.4.0` in order to capture [TTID/TTFD spans](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-initial-display)

Enable TTFD Tracing with `SentrySDK.reportFullyDisplayed()`

## Testing

- [Transactions and Errors after update](https://testorg-az.sentry.io/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&name=All+Events&project=6748045&query=sdk.version%3A8.4.0&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
- [CartViewController with new metrics](https://testorg-az.sentry.io/discover/sergio-ios:b11b3c4ec75e435496d96f9bf66deafb/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=6748045&query=sdk.version%3A8.4.0&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
- [EmpowerViewController with new metrics](https://testorg-az.sentry.io/discover/sergio-ios:e70bfd72fba64c10aca7a7810c65ad70/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=6748045&query=sdk.version%3A8.4.0&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)


