### PR TITLE
build all architecture slices for release builds

### DIFF
--- a/EmpowerPlant.xcodeproj/project.pbxproj
+++ b/EmpowerPlant.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = sentrydemos.ios.EmpowerPlant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
we think this is causing an error loading the app in the simulator in saucelabs: 
![image](https://github.com/sentry-demos/ios/assets/3241469/fbb526f3-d967-4a83-8940-7b661d53a4e3)
