### PR TITLE
fix: auth token processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An iOS app integrating Sentry to demo its various product features. See [Empower
 - Install XCode
 - In a terminal, run: 
     - `make init`
-    - `sentry-cli login` (see [`sentry-cli` docs](https://docs.sentry.io/product/cli/) for more info)
+    - `sentry-cli login` (see [`sentry-cli` docs](https://docs.sentry.io/product/cli/) for more info) and use an **org-level** auth token from the `demo` org
 
 ## Run
 Open Xcode and click the "Play" button or press ⌘R 

--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -9,7 +9,7 @@ if which sentry-cli >/dev/null; then
     fi
     if [ -z "$SENTRY_AUTH_TOKEN" ]; then
         if [ -f ~/.sentryclirc ]; then
-            export SENTRY_AUTH_TOKEN=$(grep -oE "token=(.*)$" ~/.sentryclirc | cut -d'=' -f2)
+            export SENTRY_AUTH_TOKEN=$(grep -oE "token=(.*)$" ~/.sentryclirc | sed s/'token='//)
             echo "Using SENTRY_AUTH_TOKEN from .sentryclirc."
         fi
         if [ -f ~/.zshrc ] && grep -q "export SENTRY_AUTH_TOKEN" ~/.zshrc; then


### PR DESCRIPTION
We fixed retrieving auth tokens with the new format in #46, but didn't quite process them correctly: the `token=` was still being included in the env var. 

Also added that note about using an org-level token to the readme.