### PR TITLE
build for simulator, so theres no need to sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ init:
 	stat .env 2>/dev/null || echo "SENTRY_ORG=<your org slug>\nSENTRY_PROJECT=<your project slug>" > .env
 
 release:
-	CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO xcodebuild -workspace EmpowerPlant.xcworkspace -scheme EmpowerPlant -configuration Release -derivedDataPath build -sdk iphoneos clean build 2>&1 | tee release-build.log | xcbeautify
-	zip -r EmpowerPlant_release.zip ./build/Build/Products/Release-iphoneos/EmpowerPlant.app
+	xcodebuild -workspace EmpowerPlant.xcworkspace -scheme EmpowerPlant -configuration Release -derivedDataPath build -sdk iphonesimulator clean build 2>&1 | tee release-build.log | xcbeautify
+	zip -r EmpowerPlant_release.zip ./build/Build/Products/Release-iphonesimulator/EmpowerPlant.app
 	@echo "\nBuild completed. Create a new release in GitHub and upload ./EmpowerPlant_release.zip."


### PR DESCRIPTION
`-sdk iphoneos` builds targeting real devices, so required code signing, but that's introducing some breakages among team members and since you don't yet have real device workflows, it's not necessary