### PR TITLE
Deploy script: attempt 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ init:
 	# ensure there's a .env file present
 	stat .env 2>/dev/null || echo "SENTRY_ORG=<your org slug>\nSENTRY_PROJECT=<your project slug>" > .env
 
+	# fixes CoreSimulator out of date error 
+	# (happens on fresh xcode installation or MAS-managed major version update)
+	# requires password when run without sudo
+	xcodebuild -runFirstLaunch
+
+	# download iOS platform image
+	# (happens on fresh xcode installation or MAS-managed major version update)
+	xcodebuild -downloadPlatform iOS
+
 release:
 	xcodebuild -workspace EmpowerPlant.xcworkspace -scheme EmpowerPlant -configuration Release -derivedDataPath build -sdk iphonesimulator clean build 2>&1 | tee release-build.log | xcbeautify
 	zip -r EmpowerPlant_release.zip ./build/Build/Products/Release-iphonesimulator/EmpowerPlant.app

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+# Function to display error message and exit
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Build the release bundle
+echo "Building the release bundle..."
+BUILD_OUTPUT=$(xcodebuild -workspace EmpowerPlant.xcworkspace -scheme EmpowerPlant -configuration Release clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1)
+
+# Extract the first path to the .app from the build output
+APP_PATH=$(echo "$BUILD_OUTPUT" | grep -Eo '/[^ ]+\.app($| )' | sed 's/ $//' | head -n 1)
+ZIP_PATH="EmpowerPlant_release.zip"
+
+# Check if the .app path was extracted successfully
+if [ ! -d "$APP_PATH" ]; then
+    error_exit "Failed to find .app path in the xcodebuild output."
+fi
+
+# Zip the .app file
+echo "Zipping up the .app file to $ZIP_PATH..."
+zip -rq "$ZIP_PATH" "$APP_PATH"
+
+# Check if gh is installed
+if ! command -v gh &> /dev/null; then
+    echo "gh is not installed, installing now..."
+    
+    # Install gh via Homebrew for macOS
+    if ! command -v brew &> /dev/null; then
+        # Install Homebrew if it's not installed
+        echo "Homebrew not found. Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || error_exit "Failed to install Homebrew."
+    fi
+
+    brew install gh || error_exit "Failed to install gh."
+fi
+
+# Get release version
+if [ "$#" -eq 1 ]; then
+    TAG="$1"
+else
+    # Fetch the most recent release tag using gh and sort
+    LATEST_RELEASE=$(gh release list | sort -V | tail -n 1 | awk '{print $1}')
+    if [ -z "$LATEST_RELEASE" ]; then
+        LATEST_RELEASE="0.0.0"
+    fi
+    # Split the version and increment the last digit
+    IFS='.' read -ra VERSION_PARTS <<< "$LATEST_RELEASE"
+    LAST_DIGIT_INCREMENTED=$(( ${VERSION_PARTS[2]} + 1 ))
+    TAG="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$LAST_DIGIT_INCREMENTED"
+fi
+
+TITLE="$TAG"
+NOTES="Generated automatically by ios/deploy_project.sh"
+
+# Create the GitHub release with the attached iOS build zip
+gh release create $TAG $ZIP_PATH -t "$TITLE" -n "$NOTES" || error_exit "Failed to create GitHub release."
+
+echo "Release created successfully with version $TAG!"
+


### PR DESCRIPTION
Implements all PR comments (except for `craft`) from https://github.com/sentry-demos/ios/pull/35 
plus rebased

# Testing
Successfully deployed this other PR using it: https://github.com/sentry-demos/ios/pull/51
[sample event](https://demo.sentry.io/issues/4221692556/events/d941ef8d50d84f4c8acbb7e71ece015a/) - note `se:tda` in tags
```
...
[EmpowerPlant] Linking EmpowerPlant
[EmpowerPlant] Processing Info.plist
[EmpowerPlant] Generating EmpowerPlant.app.dSYM
[EmpowerPlant] Running script [CP] Embed Pods Frameworks
[EmpowerPlant] Running script [Sentry] Upload debug symbols
Signing EmpowerPlant.app (in target 'EmpowerPlant' from project 'EmpowerPlant')
[EmpowerPlant] Touching EmpowerPlant.app
⚠️  /Users/kosty/home/ios/Pods/Pods.xcodeproj: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.0.99. (in target 'Pods-EmpowerPlant' from project 'Pods')
note: Run script build phase '[Sentry] Upload debug symbols' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'EmpowerPlant' from project 'EmpowerPlant')
/Users/kosty/home/ios/Pods/Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.0.99. (in target 'SentryPrivate' from project 'Pods')
⚠️  /Users/kosty/home/ios/Pods/Pods.xcodeproj: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.0.99. (in target 'Sentry' from project 'Pods')
** BUILD SUCCEEDED **

zip -r EmpowerPlant_release.zip ./build/Build/Products/Release-iphonesimulator/EmpowerPlant.app
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/_CodeSignature/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/_CodeSignature/CodeResources (deflated 73%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/UINavigationController-zLm-2U-p5i.nib (deflated 42%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/VXN-aD-u60-view-POk-yY-fGn.nib (deflated 67%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/UIViewController-VXN-aD-u60.nib (deflated 36%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC.nib (deflated 40%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/a38-3e-3Io-view-08s-ul-IVG.nib (deflated 35%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/UIViewController-a38-3e-3Io.nib (deflated 35%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/Main.storyboardc/Info.plist (deflated 49%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/LaunchScreen.storyboardc/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/LaunchScreen.storyboardc/01J-lp-oVM-view-Ze5-6b-2t3.nib (deflated 38%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/LaunchScreen.storyboardc/UIViewController-01J-lp-oVM.nib (deflated 35%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Base.lproj/LaunchScreen.storyboardc/Info.plist (deflated 42%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Model.momd/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Model.momd/VersionInfo.plist (deflated 20%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Model.momd/Model.mom (deflated 33%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/EmpowerPlant (deflated 77%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/SentryPrivate.framework/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/SentryPrivate.framework/_CodeSignature/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/SentryPrivate.framework/_CodeSignature/CodeResources (deflated 77%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/SentryPrivate.framework/Info.plist (deflated 29%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/SentryPrivate.framework/SentryPrivate (deflated 77%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/Sentry.framework/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/Sentry.framework/_CodeSignature/ (stored 0%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/Sentry.framework/_CodeSignature/CodeResources (deflated 77%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/Sentry.framework/Sentry (deflated 69%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Frameworks/Sentry.framework/Info.plist (deflated 29%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/Info.plist (deflated 38%)
updating: build/Build/Products/Release-iphonesimulator/EmpowerPlant.app/PkgInfo (stored 0%)

Build completed. Create a new release in GitHub and upload ./EmpowerPlant_release.zip.
https://github.com/sentry-demos/ios/releases/tag/0.0.11.1
Release created successfully with version 0.0.11.1!
```