### PR TITLE
Automatically capture  tag from environment $USER

### DIFF
--- a/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
+++ b/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
@@ -67,6 +67,13 @@
             ReferencedContainer = "container:EmpowerPlant.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "USER"
+            value = "$(USER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -33,6 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         SentrySDK.configureScope{ scope in
             scope.setTag(value: ["corporate", "enterprise", "self-serve"].randomElement() ?? "unknown", key: "customer.type")
+            scope.setTag(value: ProcessInfo.processInfo.environment["USER"] ?? "tda", key: "se")
         }
         return true
     }


### PR DESCRIPTION
Resolves https://github.com/sentry-demos/ios/issues/42

$USER will be set only when running in XCode. Therefore we assume that if it's not set, then it's in TDA. In reality this could be an older version of course.

### Testing
local simulator [sample error](https://demo.sentry.io/issues/4221692556/events/latest/?project=6249899&query=is%3Aunresolved&referrer=latest-event&statsPeriod=14d&stream_index=1)
TDA[ sample error](https://demo.sentry.io/issues/4221692556/events/d941ef8d50d84f4c8acbb7e71ece015a/)