### PR TITLE
fix: add homebrew location to PATH when running upload-symbols.sh in Xcode GUI

### DIFF
--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+
 if which sentry-cli >/dev/null; then
 
     # get SENTRY_ORG and SENTRY_PROJECT values


### PR DESCRIPTION
the build was failing when i tried to run the app locally because Xcode GUI has its own PATH that doesn't include the homebrew prefix.