### PR TITLE
fix: make navbar buttons visible

### DIFF
--- a/EmpowerPlant/Base.lproj/Main.storyboard
+++ b/EmpowerPlant/Base.lproj/Main.storyboard
@@ -48,7 +48,9 @@
                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="My Cart" id="HBc-3M-t3f">
-                        <barButtonItem key="backBarButtonItem" title="Empower Plants" id="SPv-hU-fem"/>
+                        <barButtonItem key="backBarButtonItem" title="Empower Plants" id="SPv-hU-fem">
+                            <color key="tintColor" name="AccentColor"/>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lXk-wB-WcC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/EmpowerPlant/Base.lproj/Main.storyboard
+++ b/EmpowerPlant/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zLm-2U-p5i">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zLm-2U-p5i">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -27,7 +27,11 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemGreenColor"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Empower Plants" id="Zxx-KE-qjy"/>
+                    <navigationItem key="navigationItem" title="Empower Plants" id="Zxx-KE-qjy">
+                        <barButtonItem key="backBarButtonItem" title="Empower Plants" id="53r-4t-Q7n">
+                            <color key="tintColor" name="AccentColor"/>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <segue destination="a38-3e-3Io" kind="show" identifier="goToCart" id="wPz-jB-LrC"/>
                         <segue destination="VXN-aD-u60" kind="show" identifier="goToListApp" id="ooB-np-j7X"/>
@@ -211,7 +215,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Actions" id="r5d-gZ-zyX">
-                        <barButtonItem key="backBarButtonItem" title="Empower Plants" id="Yiv-HT-IE1"/>
+                        <barButtonItem key="backBarButtonItem" title="Empower Plants" id="Yiv-HT-IE1">
+                            <color key="tintColor" name="AccentColor"/>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bgO-GR-jh9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -249,7 +255,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/EmpowerPlant/Base.lproj/Main.storyboard
+++ b/EmpowerPlant/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -223,7 +224,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="ZRT-xt-jev">
                         <rect key="frame" x="0.0" y="48" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="tintColor" name="AccentColor"/>
                         <textAttributes key="largeTitleTextAttributes">
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </textAttributes>
@@ -239,6 +240,9 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -62,7 +62,6 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
             target: self,
             action: #selector(purchase)
         )
-        self.navigationItem.rightBarButtonItem?.tintColor = UIColor.blue
         self.navigationItem.rightBarButtonItem?.accessibilityIdentifier = "Purchase"
     }
 

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -146,7 +146,6 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
             target: self,
             action: #selector(goToCart) // addToDb
         )
-        self.navigationItem.rightBarButtonItem?.tintColor = UIColor.blue
         self.navigationItem.rightBarButtonItem?.accessibilityIdentifier = "Cart"
         //self.navigationItem.rightBarButtonItem?.badgeValue = "\(1)"
         
@@ -156,7 +155,6 @@ class EmpowerPlantViewController: UIViewController, UITableViewDelegate, UITable
             target: self,
             action: #selector(goToListApp) // clearDb
         )
-        self.navigationItem.leftBarButtonItem?.tintColor = UIColor.blue
     }
     
     // Writes to CoreData database

--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+
 if which sentry-cli >/dev/null; then
 
     # get SENTRY_ORG and SENTRY_PROJECT values


### PR DESCRIPTION
For the longest time I didn't know there were back buttons in the top left. I thought i'd have to restart the app to get back to the initial screen! This makes them visible again, as well as making the text and icons all the same shade of blue.

Before:
![Screenshot 2023-10-05 at 2 17 42 PM](https://github.com/sentry-demos/ios/assets/3241469/fb7280d7-8e5c-4251-8ccc-f48b81e8316d)
![Screenshot 2023-10-05 at 2 17 52 PM](https://github.com/sentry-demos/ios/assets/3241469/e1effcc8-fef2-43fd-9aef-6113d7708fe6)


After:
![Screenshot 2023-10-05 at 2 16 42 PM](https://github.com/sentry-demos/ios/assets/3241469/06e29120-319b-41f0-a307-9bfe95c6727e)

![Screenshot 2023-10-05 at 2 16 30 PM](https://github.com/sentry-demos/ios/assets/3241469/74343881-7080-4af2-a845-c81885723a70)
