### PR TITLE
Feature/add custom metrics

### DIFF
--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let enableSwizzling = !ProcessInfo.processInfo.arguments.contains("--disable-swizzling")
         
         SentrySDK.start { options in
-            options.dsn = "https://c88045e430864a8e864af6233e7c18ea@o87286.ingest.sentry.io/6249899"
+            options.dsn = "https://48f441ffcd372c5ce788c7a0bf945509@o4504533099937792.ingest.us.sentry.io/4507058089361408"
             
             // set the SDK debug mode according to defaults and overrides.
             #if DEBUG
@@ -38,6 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.attachViewHierarchy = true
             options.enableSwizzling = enableSwizzling
             options.enablePerformanceV2 = true
+            options.enableMetrics = true
         }
         SentrySDK.configureScope{ scope in
             scope.setTag(value: ["corporate", "enterprise", "self-serve"].randomElement() ?? "unknown", key: "customer.type")

--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let enableSwizzling = !ProcessInfo.processInfo.arguments.contains("--disable-swizzling")
         
         SentrySDK.start { options in
-            options.dsn = "https://48f441ffcd372c5ce788c7a0bf945509@o4504533099937792.ingest.us.sentry.io/4507058089361408"
+            options.dsn = "https://c88045e430864a8e864af6233e7c18ea@o87286.ingest.sentry.io/6249899"
             
             // set the SDK debug mode according to defaults and overrides.
             #if DEBUG

--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -113,6 +113,8 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
                     SentrySDK.metrics.increment(key: "checkout.error")
                     let err = PurchaseError.insufficientInventory
                     SentrySDK.capture(error: err) //Empowerplant Flagship Error
+                } else {
+                    SentrySDK.metrics.increment(key: "checkout.success")
                 }
             }
 

--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -110,6 +110,7 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
             if let httpResponse = response as? HTTPURLResponse {
                 if (httpResponse.statusCode) == 500 {
                     print("> 500 response")
+                    SentrySDK.metrics.increment(key: "checkout.error")
                     let err = PurchaseError.insufficientInventory
                     SentrySDK.capture(error: err) //Empowerplant Flagship Error
                 }

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -303,7 +303,9 @@ class EmpowerPlantViewController: UIViewController {
     
     // Also writes them into database if database is empty
     func getAllProductsFromServer() {
-        let url = URL(string: "https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products-join")!
+        let startTime = Date()
+        let urlStr = "https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products-join"
+        let url = URL(string: urlStr)!
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
@@ -319,6 +321,15 @@ class EmpowerPlantViewController: UIViewController {
         }
         
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            let endTime = Date()
+            let duration = endTime.timeIntervalSince(startTime)
+            SentrySDK.metrics.distribution(
+                key: "products_request.duration",
+                value: duration,
+                unit: MeasurementUnitDuration.millisecond,
+                tags: ["endpoint": urlStr]
+            )
+            
             if let data = data {
                 if let productsResponse = try? JSONDecoder().decode([ProductMap].self, from: data) {
                     if (self.products.count == 0) {
@@ -359,6 +370,7 @@ class EmpowerPlantViewController: UIViewController {
     
     @objc
     func goToCart() {
+        SentrySDK.metrics.increment(key: "checkout.click")
         self.performSegue(withIdentifier: "goToCart", sender: self)
     }
     


### PR DESCRIPTION
# Description

Add custom metrics to the Android demo app. These replicate the same metrics that were added to our react service [here](https://github.com/sentry-demos/empower/pull/376)

- `products_request.duration`
- `checkout.click`
- `checkout.error`
- `checkout.success`


