### PR TITLE
fix: dont compute so many fibonacci numbers

### DIFF
--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -138,7 +138,7 @@ class EmpowerPlantViewController: UIViewController {
             n2 = nR + n2
         }
         
-        if (n1 < 4000) {
+        if (n1 < 500) {
             return fibonacciSeries(num: n1)
         }
         return n1


### PR DESCRIPTION
I tried running the demo on an iPhone 14, and it crashes with an arithmetic overflow when computing around the 650th fibonacci number. It is probably due to running an optimized build? Doubt it's due to the different device, since both my phone and mac are running an apple silicon arm chip.

Just dialing down the limit from 4000 to 500 fib numbers fixed it.