### PR TITLE
forcing /checkout to fail via `validate_inventory: "true"`

### DIFF
--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -92,6 +92,7 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
                     // ["id":"5", "title":"Plant Stroller"]
                 ]
             ],
+            "validate_inventory": "true"
         ]
 
         let bodyData = try? JSONSerialization.data(


### PR DESCRIPTION
flask's /checkout does not error out unless you now pass it validate_inventory: "true" in the body

This change was made a few days ago via https://github.com/sentry-demos/empower/pull/573