### PR TITLE
fix: set spec to the currently resolved version

### DIFF
--- a/EmpowerPlant.xcodeproj/project.pbxproj
+++ b/EmpowerPlant.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.24.0;
+				minimumVersion = 8.47.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
for some reason on a clean checkout of master i was unable to get xcode to actually install 8.47.0, which is what is listed in the Package.resolved file. i don't know how these drifted. It installed a prior version that didn't yet have session replay options moved out of experimental, so the build errored for me. The change in this PR got everything working again.