### PR TITLE
fix: background color issue when pushing to cart

### DIFF
--- a/EmpowerPlant/CartViewController.swift
+++ b/EmpowerPlant/CartViewController.swift
@@ -34,8 +34,7 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     required init?(coder: NSCoder) {
-        //fatalError("init(coder:) has not been implemented")
-        super.init(nibName: nil, bundle: nil)
+        super.init(coder: coder)
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
someone replaced the required initializer for proper function from storyboard with the wrong superclass init call. that can cause all kinds of weirdness

|before|after|
|---|---|
|<img width="549" height="1045" alt="image" src="https://github.com/user-attachments/assets/1376cb71-2be4-41e3-8e9f-147d00879afb" />|<img width="549" height="1045" alt="image" src="https://github.com/user-attachments/assets/7ce613b5-daed-40ba-a9c2-cb4bb6c5ca47" />|