### PR TITLE
ci: use macOS 15 for jobs and iPhone 16 as test destination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   empower-plant-release:
     name: Release Build of EmpowerPlant
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Setup Sentry CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ init:
 
 .PHONY: test
 test:
-	xcodebuild -project EmpowerPlant.xcodeproj -scheme EmpowerPlant -configuration Test -derivedDataPath build -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" -quiet test
+	xcodebuild -project EmpowerPlant.xcodeproj -scheme EmpowerPlant -configuration Test -derivedDataPath build -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" -quiet test
 	slather coverage --configuration Test --verbose


### PR DESCRIPTION
The SPM tooling version is lagging behind the current tools (Xcode 16.4 ships SPM integration version 3) (see the diff in https://github.com/sentry-demos/ios/pull/111, this is something we saw going back and forth a bunch in the past)