### PR TITLE
test: allow overriding DSN when launching demo from Xcode

### DIFF
--- a/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
+++ b/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
@@ -91,6 +91,11 @@
             value = "$(USER)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "--dsn"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let enableSwizzling = !ProcessInfo.processInfo.arguments.contains("--disable-swizzling")
         
         SentrySDK.start { options in
-            options.dsn = "https://9b0dbdfd24daad3f475baa5f5adf1302@sandbox-mirror.sentry.gg/1"
+            options.dsn = ProcessInfo.processInfo.environment["--dsn"] ?? "https://9b0dbdfd24daad3f475baa5f5adf1302@sandbox-mirror.sentry.gg/1"
             
             // set the SDK debug mode according to defaults and overrides.
             #if DEBUG


### PR DESCRIPTION
Avoids having to change it in code and potentially having to go back and forth in PRs like in #103 

This is a debug-time complement to https://github.com/sentry-demos/ios/pull/115 which would allow doing this in the running app without relaunching.