### PR TITLE
impr: allow bypassing slow launch work

### DIFF
--- a/EmpowerPlant.xcodeproj/project.pbxproj
+++ b/EmpowerPlant.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		843226DB2E29E12C000311A4 /* SlowOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843226DA2E29E12C000311A4 /* SlowOperations.swift */; };
 		843BD60F2AD08CE900B0098F /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843BD60E2AD08CE900B0098F /* Utils.swift */; };
 		843BD6272AD7798C00B0098F /* jwt-deep-field.png in Resources */ = {isa = PBXBuildFile; fileRef = 843BD6262AD7798C00B0098F /* jwt-deep-field.png */; };
 		846BEA1C2ABE611A0032F77F /* mobydick.txt in Resources */ = {isa = PBXBuildFile; fileRef = 846BEA1B2ABE611A0032F77F /* mobydick.txt */; };
@@ -40,6 +41,7 @@
 
 /* Begin PBXFileReference section */
 		840B7EF12BBF3C70008B8120 /* .slather.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .slather.yml; sourceTree = "<group>"; };
+		843226DA2E29E12C000311A4 /* SlowOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowOperations.swift; sourceTree = "<group>"; };
 		843BD60E2AD08CE900B0098F /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		843BD6262AD7798C00B0098F /* jwt-deep-field.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "jwt-deep-field.png"; sourceTree = "<group>"; };
 		846BEA1A2ABE46880032F77F /* upload-symbols.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "upload-symbols.sh"; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				843BD60E2AD08CE900B0098F /* Utils.swift */,
 				D15FCDA727E00F0D00258BF3 /* Model.xcdatamodeld */,
 				D17C73CB27D82EB8006650AF /* EmpowerPlantViewController.swift */,
+				843226DA2E29E12C000311A4 /* SlowOperations.swift */,
 				846BEA1B2ABE611A0032F77F /* mobydick.txt */,
 				D19EBE6E2805ED52007022DC /* ShoppingCart.swift */,
 				D17C73CE27D82ED1006650AF /* CartViewController.swift */,
@@ -283,6 +286,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				843226DB2E29E12C000311A4 /* SlowOperations.swift in Sources */,
 				D17C73CC27D82EB8006650AF /* EmpowerPlantViewController.swift in Sources */,
 				D17C73D227D83321006650AF /* ListAppViewController.swift in Sources */,
 				D15EDF14282BF80400FC13D6 /* Product+CoreDataClass.swift in Sources */,

--- a/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
+++ b/EmpowerPlant.xcodeproj/xcshareddata/xcschemes/EmpowerPlant.xcscheme
@@ -73,6 +73,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--skip-slow-launch-work"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--no-debug-mode-in-debug-build"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/EmpowerPlant/EmpowerPlantViewController.swift
+++ b/EmpowerPlant/EmpowerPlantViewController.swift
@@ -49,12 +49,9 @@ class EmpowerPlantViewController: UIViewController {
         
         getAllProductsFromServer()
         getAllProductsFromDb()
-        readCurrentDirectory()
-        performLongFileOperation()
         processProducts()
         checkRelease()
-        
-        
+
         NotificationCenter.default.addObserver(forName: modifiedDBNotificationName, object: nil, queue: nil) { _ in
             self.getAllProductsFromDb()
         }
@@ -62,86 +59,21 @@ class EmpowerPlantViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
+        if !ProcessInfo.processInfo.arguments.contains("--skip-slow-launch-work") {
+            SlowOperation.fileRead()
+            SlowOperation.fileWrite()
+        }
+
         SentrySDK.reportFullyDisplayed()
-    }
-    
-    func performLongFileOperation() {
-        let longString = String(repeating: UUID().uuidString, count: 5_000_000)
-        let data = longString.data(using: .utf8)!
-        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent("tmp" + UUID().uuidString)
-        try! data.write(to: filePath)
-        try! FileManager.default.removeItem(at: filePath)
     }
 
     func processProducts() {
         let span = SentrySDK.span?.startChild(operation: "product_processing")
-        _ = getIterator(42);
-        sleep(50 / 1000)
+        if !ProcessInfo.processInfo.arguments.contains("--skip-slow-launch-work") {
+            SlowOperation.computation()
+        }
         span?.finish()
-    }
-
-    func getIterator(_ n: Int) -> Int {
-       if (n <= 0) {
-           return 0;
-       }
-       if (n == 1 || n == 2) {
-           return 1;
-       }
-       return getIterator(n - 1) + getIterator(n - 2);
-   }
-
-    
-    func readCurrentDirectory() {
-        let path = FileManager.default.currentDirectoryPath
-        do {
-            let items = try FileManager.default.contentsOfDirectory(atPath: path)
-            let loop = fibonacciSeries(num: items.count)
-            for i in 1...loop {
-                readDirectory(path: path)
-            }
-        } catch {
-            // TODO: error
-        }
-    }
-    
-    func readDirectory(path: String) {
-        let fm = FileManager.default
-        
-        do {
-            let items = try fm.contentsOfDirectory(atPath: path)
-            
-            for item in items {
-                var isDirectory: ObjCBool = false
-                if fm.fileExists(atPath: item, isDirectory: &isDirectory) {
-                    readDirectory(path: item)
-                } else {
-                    return
-                }
-            }
-        } catch {
-            // TODO: error
-        }
-        
-    }
-    
-    func fibonacciSeries(num: Int) -> Int{
-        // The value of 0th and 1st number of the fibonacci series are 0 and 1
-        var n1 = 0
-        var n2 = 1
-        
-        // To store the result
-        var nR = 0
-        // Adding two previous numbers to find ith number of the series
-        for _ in 0..<num{
-            nR = n1
-            n1 = n2
-            n2 = nR + n2
-        }
-        
-        if (n1 < 500) {
-            return fibonacciSeries(num: n1)
-        }
-        return n1
     }
     
     @objc

--- a/EmpowerPlant/SlowOperations.swift
+++ b/EmpowerPlant/SlowOperations.swift
@@ -1,0 +1,92 @@
+//
+//  SlowOperations.swift
+//  EmpowerPlant
+//
+//  Created by Andrew McKnight on 7/17/25.
+//
+
+import Foundation
+
+/// Utilities to simulate slow operations, to help demonstrate how Sentry can help pinpoint such issues in real apps.
+struct SlowOperation {
+    /// Simulate a long-running file write operation by building a large string and writing it to disk, then deleting it again.
+    static public func fileWrite() {
+        let longString = String(repeating: UUID().uuidString, count: 5_000_000)
+        let data = longString.data(using: .utf8)!
+        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent("tmp" + UUID().uuidString)
+        try! data.write(to: filePath)
+        try! FileManager.default.removeItem(at: filePath)
+    }
+
+    /// Simulate a long-running file read operation by slowly calculate a number of times to iterate, then depth-first search a directory structure that many times.
+    static public func fileRead() {
+        let path = FileManager.default.currentDirectoryPath
+        do {
+            let items = try FileManager.default.contentsOfDirectory(atPath: path)
+            let loop = fibonacciSeries(num: items.count)
+            for _ in 1...loop {
+                readDirectory(path: path)
+            }
+        } catch {
+            // TODO: error
+        }
+    }
+
+    /// Simulate a long-running CPU-bound operation
+    static public func computation() {
+        _ = getIterator(42);
+        sleep(50 / 1000)
+    }
+}
+
+private extension SlowOperation {
+    static func readDirectory(path: String) {
+        let fm = FileManager.default
+
+        do {
+            let items = try fm.contentsOfDirectory(atPath: path)
+
+            for item in items {
+                var isDirectory: ObjCBool = false
+                // TODO: check the value of isDirectory after fileExists, unless we want the errors to happen when calling contentsOfDirectory on a path that's not a directory?
+                if fm.fileExists(atPath: item, isDirectory: &isDirectory) {
+                    readDirectory(path: item)
+                } else {
+                    return
+                }
+            }
+        } catch {
+            // TODO: error
+        }
+    }
+
+    static func fibonacciSeries(num: Int) -> Int{
+        // The value of 0th and 1st number of the fibonacci series are 0 and 1
+        var n1 = 0
+        var n2 = 1
+
+        // To store the result
+        var nR = 0
+        // Adding two previous numbers to find ith number of the series
+        for _ in 0..<num{
+            nR = n1
+            n1 = n2
+            n2 = nR + n2
+        }
+
+        if (n1 < 500) {
+            return fibonacciSeries(num: n1)
+        }
+        return n1
+    }
+
+    static func getIterator(_ n: Int) -> Int {
+       if (n <= 0) {
+           return 0;
+       }
+       if (n == 1 || n == 2) {
+           return 1;
+       }
+       return getIterator(n - 1) + getIterator(n - 2);
+    }
+}


### PR DESCRIPTION
Added a launch argument to the schema, disabled by default for now, that can be enabled to skip the slow launch demo sequence. This will make iterative development on the app itself less painful.

Also refactored to extract all the simulation code to a dedicated file for the purpose, to further unclutter EmpowerPlantViewController from too much non-UI/nav code.