### PR TITLE
Update sentry-cocoa SDK to 9.8.0

### DIFF
--- a/EmpowerPlant.xcodeproj/project.pbxproj
+++ b/EmpowerPlant.xcodeproj/project.pbxproj
@@ -735,7 +735,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 9.5.0;
+				version = 9.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/EmpowerPlant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EmpowerPlant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "c97459fd75243c620a09a1e6219e63aaec37555e",
-        "version" : "9.5.0"
+        "revision" : "05d3ce8332097ff0b2347231ac66476fd7d2f4d8",
+        "version" : "9.8.0"
       }
     },
     {

--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -32,7 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             #endif
 
             options.tracesSampleRate = 1.0
-            options.configureProfiling = { $0.sessionSampleRate = 1 }
+            options.configureProfiling = {
+                $0.sessionSampleRate = 1
+                $0.lifecycle = .trace
+            }
             options.attachScreenshot = true
             options.attachViewHierarchy = true
             options.enableSwizzling = enableSwizzling


### PR DESCRIPTION
## Summary
- Bump sentry-cocoa from 9.5.0 → 9.8.0
- Set profiling lifecycle to `.trace` so profiles auto-start/stop with root spans
