### PR TITLE
Add accessibility identifiers for Saucelabs test stability

### DIFF
--- a/EmpowerPlant/CartItemCell.swift
+++ b/EmpowerPlant/CartItemCell.swift
@@ -58,6 +58,7 @@ class CartItemCell: UITableViewCell {
     func configure(name: String, quantity: Int) {
         productNameLabel.text = name
         quantityLabel.text = "Qty: \(quantity)"
+        accessibilityIdentifier = "CartItem_\(name)"
     }
 
     // MARK: - Reuse

--- a/EmpowerPlant/ProductTableViewCell.swift
+++ b/EmpowerPlant/ProductTableViewCell.swift
@@ -124,7 +124,10 @@ class ProductTableViewCell: UITableViewCell {
     // MARK: - Configuration
 
     func configure(name: String?, price: String?, imageURL: String?) {
-        nameLabel.text = name ?? "Unknown"
+        let safeName = name ?? "Unknown"
+        nameLabel.text = safeName
+        accessibilityIdentifier = "ProductCell_\(safeName)"
+        addToCartButton.accessibilityIdentifier = "AddToCart_\(safeName)"
 
         if let priceStr = price, let priceInt = Int(priceStr) {
             priceLabel.text = "$\(priceInt)"


### PR DESCRIPTION
## Summary
- Add `accessibilityIdentifier` to `ProductTableViewCell` (cell + Add to Cart button) and `CartItemCell`
- Enables Saucelabs tests to use stable `accessibility id` selectors instead of brittle XPath that breaks on view hierarchy changes

## Test plan
- [ ] Build and run on iOS Simulator
- [ ] Verify accessibility identifiers are set via Xcode Accessibility Inspector
- [ ] Update Saucelabs test scripts to use `accessibility id` selectors (e.g. `AddToCart_Spider Plant`, `CartItem_Plant Mood`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)