### PR TITLE
Enable Sentry Size Analysis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,27 @@ jobs:
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v1.3.0
         with:
-          version: 2.21.2
+          version: latest
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Run Deploy Script
         run: ./deploy_project.sh ${{ github.event.inputs.version }} ${{ secrets.SENTRY_ORG }} ${{ secrets.SENTRY_PROJECT }} ${{ secrets.SENTRY_AUTH_TOKEN }}
         shell: sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to Sentry Size Analysis
+        run: |
+          xcodebuild archive \
+            -project EmpowerPlant.xcodeproj \
+            -scheme EmpowerPlant \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath build/EmpowerPlant.xcarchive \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            -quiet
+          sentry-cli build upload build/EmpowerPlant.xcarchive \
+            --org ${{ secrets.SENTRY_ORG }} \
+            --project ${{ secrets.SENTRY_PROJECT }} \
+            --build-configuration Release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v1.3.0
         with:
-          version: latest
+          version: 3.3.5
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Run Deploy Script
         run: ./deploy_project.sh ${{ github.event.inputs.version }} ${{ secrets.SENTRY_ORG }} ${{ secrets.SENTRY_PROJECT }} ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,6 @@ jobs:
             --project ${{ secrets.SENTRY_PROJECT }} \
             --build-configuration Release \
             --head-sha ${{ github.sha }} \
-            --head-ref ${{ github.ref_name }}
+            --head-ref "${{ github.ref_name }}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
             --project ${{ secrets.SENTRY_PROJECT }} \
             --build-configuration Release \
             --head-sha ${{ github.sha }} \
-            --head-ref "${{ github.ref_name }}"
+            --head-ref "${{ github.ref_name }}" \
+            --vcs-provider github \
+            --head-repo-name ${{ github.repository }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload to Sentry Size Analysis
         run: |
-          xcodebuild archive \
-            -project EmpowerPlant.xcodeproj \
-            -scheme EmpowerPlant \
-            -configuration Release \
-            -destination "generic/platform=iOS" \
-            -archivePath build/EmpowerPlant.xcarchive \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            -quiet
           sentry-cli build upload build/EmpowerPlant.xcarchive \
             --org ${{ secrets.SENTRY_ORG }} \
             --project ${{ secrets.SENTRY_PROJECT }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           sentry-cli build upload build/EmpowerPlant.xcarchive \
             --org ${{ secrets.SENTRY_ORG }} \
             --project ${{ secrets.SENTRY_PROJECT }} \
-            --build-configuration Release
+            --build-configuration Release \
+            --head-sha ${{ github.sha }} \
+            --head-ref ${{ github.ref_name }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,48 @@ jobs:
         token: 214d9137-2c5a-4eaf-9327-c6031f13795a
         fail_ci_if_error: true
         verbose: true
+
+    - name: Setup Sentry CLI
+      uses: mathieu-bour/setup-sentry-cli@v1.3.0
+      with:
+        version: 3.3.5
+        token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+    - name: Upload to Sentry Size Analysis
+      run: |
+        xcodebuild archive \
+          -project EmpowerPlant.xcodeproj \
+          -scheme EmpowerPlant \
+          -configuration Release \
+          -destination "generic/platform=iOS" \
+          -archivePath build/EmpowerPlant.xcarchive \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          -quiet
+
+        HEAD_REF="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+        UPLOAD_ARGS=(
+          --org "$SENTRY_ORG"
+          --project "$SENTRY_PROJECT"
+          --build-configuration Release
+          --head-sha "$GITHUB_SHA"
+          --head-ref "$HEAD_REF"
+          --vcs-provider github
+          --head-repo-name "$GITHUB_REPOSITORY"
+        )
+
+        if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          UPLOAD_ARGS+=(
+            --base-sha "$PR_BASE_SHA"
+            --base-ref "$GITHUB_BASE_REF"
+            --pr-number "$PR_NUMBER"
+          )
+        fi
+
+        sentry-cli build upload build/EmpowerPlant.xcarchive "${UPLOAD_ARGS[@]}"
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -13,11 +13,23 @@ SENTRY_ORG_INPUT=${2}
 SENTRY_PROJECT_INPUT=${3}
 SENTRY_AUTH_TOKEN_INPUT=${4}
 
-# Build the release bundle
-echo "Building the release bundle..."
+# Build the simulator bundle (for Saucelabs / GitHub release zip)
+echo "Building the simulator bundle..."
 SENTRY_ORG=$SENTRY_ORG_INPUT SENTRY_PROJECT=$SENTRY_PROJECT_INPUT SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN_INPUT xcodebuild -project EmpowerPlant.xcodeproj -scheme EmpowerPlant -configuration Release -derivedDataPath build -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" -quiet clean build
 zip -r EmpowerPlant_release.zip ./build/Build/Products/Release-iphonesimulator/EmpowerPlant.app
 ZIP_PATH="./EmpowerPlant_release.zip"
+
+# Build the XCArchive (for Sentry Size Analysis upload)
+echo "Building XCArchive for Sentry Size Analysis..."
+xcodebuild archive \
+  -project EmpowerPlant.xcodeproj \
+  -scheme EmpowerPlant \
+  -configuration Release \
+  -destination "generic/platform=iOS" \
+  -archivePath build/EmpowerPlant.xcarchive \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -quiet
 
 # Check if gh is installed
 if ! command -v gh &> /dev/null; then


### PR DESCRIPTION
## Summary
- Updates sentry-cli from `2.21.2` to `latest` (v3.3.5+ required for Size Analysis)
- Adds a new **Upload to Sentry Size Analysis** step to `release.yml` that:
  1. Builds an XCArchive for `generic/platform=iOS` (code signing disabled — no distribution cert in CI)
  2. Uploads the archive via `sentry-cli build upload` so Sentry can track binary size across releases

The existing simulator build and GitHub release zip steps are unchanged.

## Test plan
- Trigger the `release.yml` workflow via `workflow_dispatch`
- Confirm the new "Upload to Sentry Size Analysis" step passes
- Check Sentry → Size Analysis for a new build entry with binary size breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)