### PR TITLE
feat: Enabled Standalone App Start + Session Replay Network Recording

### DIFF
--- a/EmpowerPlant.xcodeproj/project.pbxproj
+++ b/EmpowerPlant.xcodeproj/project.pbxproj
@@ -735,7 +735,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 9.8.0;
+				version = 9.16.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/EmpowerPlant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EmpowerPlant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "05d3ce8332097ff0b2347231ac66476fd7d2f4d8",
-        "version" : "9.8.0"
+        "revision" : "e6d00b6171c0c055debdf278554db035ae958926",
+        "version" : "9.16.1"
       }
     },
     {

--- a/EmpowerPlant/AppDelegate.swift
+++ b/EmpowerPlant/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableSwizzling = enableSwizzling
             options.enableAutoPerformanceTracing = true
             options.enableTimeToFullDisplayTracing = true
+            options.experimental.enableStandaloneAppStartTracing = true
             
             // Enable AppHang configurations
             options.appHangTimeoutInterval = 2.0
@@ -59,6 +60,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Enable Mobile Session Replay
             options.sessionReplay.onErrorSampleRate = 1.0
             options.sessionReplay.sessionSampleRate = 1.0
+            options.experimental.enableReplayNetworkDetailsCapturing = true
+            options.sessionReplay.networkDetailAllowUrls = [
+                "https://flask.empower-plant.com",
+                "https://storage.googleapis.com",
+                "localhost"
+            ]
+            options.sessionReplay.networkCaptureBodies = true
             
             //Enable User Feedback Widget
             options.configureUserFeedback = { config in


### PR DESCRIPTION
## Summary
- Bumps sentry-cocoa from 9.8.0 to 9.16.1
- Enables standalone app start tracing (`experimental.enableStandaloneAppStartTracing`)
- Enables session replay network detail capturing with request/response bodies for flask.empower-plant.com, storage.googleapis.com, and localhost

## Demos
- Session Replay: https://demo.sentry.io/explore/replays/5215fa7fb1f940bc8e8110e96e930f59/?groupId=7528426160&referrer=/issues/:groupId/&t=0&t_main=network&n_detail_row=0&n_detail_tab=request
- Standalone App Start: https://demo.sentry.io/explore/traces/trace/03813c16373d493280ef3c8e56547e32/?cursor=0%3A50%3A0&node=span-0759b515a89b4d72&project=4508968167538688&source=traces&statsPeriod=30d&targetId=0759b515a89b4d72&timestamp=1780619565

## Test plan
- [x] Resolve packages in Xcode and confirm build succeeds
- [x] Verify standalone app start transactions appear in Sentry
- [x] Verify session replay captures network request/response bodies for allowed URLs